### PR TITLE
Properly setting dependencies for `eslint-config-coursera`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,8 @@
   },
   "homepage": "https://github.com/coursera/eslint-plugin-coursera",
   "dependencies": {
-    "eslint-config-airbnb": "^11.2.0"
-  },
-  "peerDependencies": {
+    "eslint-config-airbnb": "^11.2.0",
     "babel-eslint": "^6.0.2",
-    "eslint": "^3.5.0",
     "eslint-import-resolver-node": "^0.2.3",
     "eslint-plugin-coursera": "0.0.3",
     "eslint-plugin-flowtype": "^2.25.0",
@@ -41,5 +38,8 @@
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.1"
+  }, 
+  "peerDependencies": {
+    "eslint": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-coursera",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Coursera's approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.1"
-  }, 
+  },
   "peerDependencies": {
     "eslint": "^3.5.0"
   }


### PR DESCRIPTION
previously, we had to support a global version of `eslint` for use with arcanist, which mean we had to do some hackery to properly version global libraries. 

now that arcanist can support a local `eslint`, lets make this library do what we expect and establish its own dependencies. `eslint` will continue to be a peerDependency since the upstream repo should establish that dependency (but none of the others)