### PR TITLE
Use import/no-duplicates instead of no-duplicate-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,9 @@ module.exports = {
       },
     ],
     'newline-per-chained-call': 0,
+    // use import/no-duplicates instead
+    // https://github.com/babel/eslint-plugin-babel/issues/59
+    'no-duplicate-imports': 0,
     'no-bitwise': 2,
     'no-confusing-arrow': [
       1,
@@ -110,6 +113,7 @@ module.exports = {
     ],
     'no-continue': 2,
     'no-div-regex': 2,
+    'no-duplicates': 2,
     'no-else-return': 0,
     'no-iterator': 2,
     'no-labels': 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-coursera",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Coursera's approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Refer to this thread: https://github.com/babel/eslint-plugin-babel/issues/59

Will stop eslint from complaining when we have `import type` and `import` for the
same module in the same file. Useful in cases where the libdef has more pseudo-types
that don't have corresponding runtime definitions that are necessary for compile time checks.

@jnwng