### PR TITLE
UPGRADE: eslint-plugin-jsx-a11y 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
   "homepage": "https://github.com/coursera/eslint-plugin-coursera",
   "dependencies": {
     "babel-eslint": "^6.0.2",
-    "eslint-config-airbnb": "^11.2.0",
+    "eslint-config-airbnb": "^15.1.0",
     "eslint-config-prettier": "^1.5.0",
     "eslint-import-resolver-node": "^0.2.3",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-coursera": "0.0.3",
     "eslint-plugin-flowtype": "^2.25.0",
     "eslint-plugin-graphql": "^0.7.0",
-    "eslint-plugin-import": "^1.15.0",
-    "eslint-plugin-jsx-a11y": "^2.2.2",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.0.1",
-    "eslint-plugin-react": "^6.2.1",
+    "eslint-plugin-react": "^7.2.0",
     "prettier": "^0.22.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
ESlint-plugin-jsx-a11y has a known false positive [https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/272] which is causing some a11y related fixes to get pinged in CR, this is with it and its related dependecies (most notably eslint-airbnb-config) updated to their current versions.

If its too much of a hassle to upgrade I can also add ignores for the faulty rules on the offending lines in /web