### PR TITLE
 Adjust jsx-a11y/anchor-is-valid rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,13 @@ module.exports = {
         SwitchCase: 1,
       },
     ],
+    'jsx-a11y/anchor-is-valid': [
+      2,
+      {
+        'components': ['Link'],
+        'specialLink': ['to'],
+      },
+    ],
     'jsx-a11y/aria-props': 1,
     'jsx-a11y/aria-proptypes': 1,
     'jsx-a11y/aria-role': 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-coursera",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Coursera's approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Adjust jsx-a11y/anchor-is-valid rule to not error on Link components with valid "to" props.