### PR TITLE
use some instead of every for jsx-a11y/label-has-for

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,11 +90,9 @@ module.exports = {
     'jsx-a11y/aria-proptypes': 1,
     'jsx-a11y/aria-role': 1,
     'jsx-a11y/label-has-for': [ 1, {
-      'components': [ 'Label' ],
       'required': {
         'some': [ 'nesting', 'id' ],
       },
-      'allowChildren': false,
     }],
     'jsx-a11y/role-has-required-aria-props': 1,
     'jsx-a11y/role-supports-aria-props': 1,

--- a/index.js
+++ b/index.js
@@ -89,7 +89,13 @@ module.exports = {
     'jsx-a11y/aria-props': 1,
     'jsx-a11y/aria-proptypes': 1,
     'jsx-a11y/aria-role': 1,
-    'jsx-a11y/label-has-for': 1,
+    'jsx-a11y/label-has-for': [ 1, {
+      'components': [ 'Label' ],
+      'required': {
+        'some': [ 'nesting', 'id' ],
+      },
+      'allowChildren': false,
+    }],
     'jsx-a11y/role-has-required-aria-props': 1,
     'jsx-a11y/role-supports-aria-props': 1,
     'jsx-a11y/tabindex-no-positive': 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-coursera",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Coursera's approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
we can use either htmlFor or nesting. We do not need both.