### PR TITLE
Disabled default-props-match-prop-types rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,7 @@ module.exports = {
     'operator-linebreak': [1, 'after'],
     quotes: [1, 'single', 'avoid-escape'],
     'quote-props': [1, 'consistent'],
+    'react/default-props-match-prop-types' : 0,
     'react/forbid-prop-types': [
       1,
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-coursera",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Coursera's approach to JavaScript",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
https://github.com/facebook/flow/issues/1660
For versions 0.53+ , Flow requires a prop whose default value is defined to be required instead of optional. 
